### PR TITLE
Fix cTrader async, UI, and trading logic errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,14 +59,22 @@ class MainApp(tk.Tk):
         self.protocol("WM_DELETE_WINDOW", self.on_closing)
         
     def update_connection_status_ui(self, status: str, color: str):
-        """Callback to update the UI with connection status."""
-        if hasattr(self, 'settings_tab') and self.settings_tab.winfo_exists():
-            self.settings_tab.connection_status.config(text=status, foreground=color)
-            self.settings_tab.status_label.config(text=f"Status: {status}", foreground=color)
-            if status == "Connected":
-                self.settings_tab.disconnect_button.config(state=tk.NORMAL)
-            else:
-                self.settings_tab.disconnect_button.config(state=tk.DISABLED)
+        """
+        Callback to update the UI with connection status.
+        This method is called from the network thread, so it schedules the UI update
+        to run on the main thread using `after`.
+        """
+        def do_update():
+            if hasattr(self, 'settings_tab') and self.settings_tab.winfo_exists():
+                self.settings_tab.connection_status.config(text=status, foreground=color)
+                self.settings_tab.status_label.config(text=f"Status: {status}", foreground=color)
+                if status == "Connected":
+                    self.settings_tab.disconnect_button.config(state=tk.NORMAL)
+                else:
+                    self.settings_tab.disconnect_button.config(state=tk.DISABLED)
+
+        # Schedule the UI update to be run by the main Tkinter thread
+        self.after(0, do_update)
 
 
     def _run_event_loop(self):


### PR DESCRIPTION
This commit addresses several critical bugs reported by the user, making the cTrader connection and trading functionality more robust and stable.

- Refactored `gui/trading.py` to correctly handle asynchronous `Deferred` objects by chaining callbacks for `get_bars` and `get_positions`.
- Removed a duplicate `execute_live_trade` method that was causing `TypeError` exceptions.
- Restored the trading logic within the new `_on_bars_received` and `_on_positions_received` callbacks.
- Made UI status updates in `main.py` thread-safe by using `self.after()` to marshal calls from the network thread to the main UI thread.
- Fixed the `ProtoOAGetTrendbarsReq` `EncodeError` by adding `fromTimestamp` and `toTimestamp` to the `get_bars` method.
- Renamed `_client` to `client` in `CTraderClient` for compatibility.

## Summary by Sourcery

Improve the robustness and stability of cTrader integration by fixing async handling in trading callbacks, restoring entry/exit logic, ensuring thread-safe UI updates, and resolving encode and type errors.

Bug Fixes:
- Remove duplicate execute_live_trade method to prevent TypeError exceptions
- Add missing fromTimestamp and toTimestamp parameters in get_bars to fix ProtoOAGetTrendbarsReq EncodeError
- Make UI status updates thread-safe by scheduling them on the main thread with after()

Enhancements:
- Chain get_positions calls from _on_bars_received and add corresponding callbacks for asynchronous position processing
- Restore entry and exit trading logic within the new _on_bars_received and _on_positions_received callbacks

Chores:
- Rename CTraderClient._client to client for compatibility