### PR TITLE
Fix typo in asyncioreactor.install call

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ class MainApp(tk.Tk):
     def _run_event_loop(self):
         """Run the event loop in the background thread"""
         from twisted.internet import asyncioreactor
-        asyncioreactor.install(event_loop=self.loop)
+        asyncioreactor.install(eventloop=self.loop)
         asyncio.set_event_loop(self.loop)
         self.loop.run_forever()
 


### PR DESCRIPTION
Changed the keyword argument from `event_loop` to `eventloop` in the call to `asyncioreactor.install` in `main.py`. This fixes a `TypeError` that occurred when running the application.