### PR TITLE
Fix cTrader integration and trading functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,9 +79,8 @@ class MainApp(tk.Tk):
 
         # Create tabs
         self.trading_tab = TradingTab(self.notebook)
-        # If TradingTab expects a client, attach it
-        if hasattr(self.trading_tab, "ctrader_client"):
-            self.trading_tab.ctrader_client = self.ctrader_client
+        # Set the cTrader client for the trading tab
+        self.trading_tab.set_ctrader_client(self.ctrader_client)
 
         self.settings_tab = SettingsTab(self.notebook, self.ctrader_client)
         self.ai_tab = SachielAITab(self.notebook)
@@ -127,6 +126,7 @@ class MainApp(tk.Tk):
                 self.settings_tab.status_label.config(text=f"Status: {status}", foreground=color)
                 if status == "Connected":
                     self.settings_tab.disconnect_button.config(state=tk.NORMAL)
+                    self.trading_tab.load_symbols_if_connected()
                 else:
                     self.settings_tab.disconnect_button.config(state=tk.DISABLED)
 


### PR DESCRIPTION
This commit addresses several critical issues in the cTrader integration, allowing the application to connect, load data, and initiate trades correctly.

The key fixes are:
- Removed calls to a non-existent `initialize_clients` method in `gui/trading.py`, which was causing the application to crash when starting a trade. The logic has been replaced with proper checks for the existing `ctrader_client` instance.
- Implemented dynamic symbol loading in `gui/trading.py`. The application now fetches the list of tradable symbols from the cTrader API instead of using a hardcoded list.
- Improved connection handling in the `TradingTab`. The UI now correctly waits for a successful connection before attempting to load symbols, and the trading loop stops gracefully if the connection is lost.
- Added placeholders for unimplemented methods (`verify_connection` and `check_live_exit`) to prevent runtime errors and clarify the application's current capabilities.